### PR TITLE
AP_Relay: only log if pin states have changed

### DIFF
--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -141,13 +141,14 @@ void AP_Relay::set(const uint8_t instance, const bool value)
     if (_pin[instance] == -1) {
         return;
     }
-    uint32_t now = AP_HAL::millis();
-    _pin_states = value?_pin_states | (1<< instance): _pin_states & ~(1<< instance);
-    if (now > last + 1000) {
-       AP::logger().Write("RELY", "TimeUS,State", "QB",
+    const uint32_t now = AP_HAL::millis();
+    _pin_states = value ? _pin_states | (1U<<instance) : _pin_states & ~(1U<<instance);
+    if ((_pin_states != _last_logged_pin_states) && (now > (_last_log_ms + 100))) {
+       AP::logger().Write("RELY", "TimeUS,State", "s-", "F-", "QB",
                                         AP_HAL::micros64(),
                                         _pin_states);
-       last=now;
+       _last_log_ms = now;
+       _last_logged_pin_states = _pin_states;
     }
 #if AP_SIM_ENABLED && (CONFIG_HAL_BOARD != HAL_BOARD_SITL)
     return;

--- a/libraries/AP_Relay/AP_Relay.h
+++ b/libraries/AP_Relay/AP_Relay.h
@@ -51,7 +51,8 @@ private:
     AP_Int8 _pin[AP_RELAY_NUM_RELAYS];
     AP_Int8 _default;
     uint8_t _pin_states;
-    uint32_t last;
+    uint8_t _last_logged_pin_states;
+    uint32_t _last_log_ms;
 
     void set(uint8_t instance, bool value);
 };


### PR DESCRIPTION
Now only logs if there is a change in pin state, reduced max repeat time to 10hz. Also added units to the log.